### PR TITLE
Specify reverse aliases for premium plan

### DIFF
--- a/data/pricing/en/premium.yaml
+++ b/data/pricing/en/premium.yaml
@@ -5,8 +5,8 @@
 - title: Unlimited custom domains
   subtitle: Bring your own domain to create aliases like contact@your-domain.com
 
-- title: Create reverse aliases
-  subtitle: Create addresses where you can send emails that will be forwarded to the configured destination
+- title: Initiate a new email from your alias
+  subtitle: You can create a reverse-alias to send an email to a new contact.
 
 - title: Catch-all (or wildcard) domain
 

--- a/data/pricing/en/premium.yaml
+++ b/data/pricing/en/premium.yaml
@@ -5,6 +5,9 @@
 - title: Unlimited custom domains
   subtitle: Bring your own domain to create aliases like contact@your-domain.com
 
+- title: Create reverse aliases
+  subtitle: Create addresses where you can send emails that will be forwarded to the configured destination
+
 - title: Catch-all (or wildcard) domain
 
 - title: 5 subdomains <span class="badge badge-success">new</span>


### PR DESCRIPTION
In the free plan it was not specified that the reverse aliases could be created but we can highlight it in the premium one. I've only added it to the english version, my french is not good enough :)