### PR TITLE
Made "open-source" a link

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -11,7 +11,7 @@ hero_desc: >
   title="An email alias (or alias for short) is an email address that <b>doesn't store</b> emails: all emails sent to an alias are forwarded to your personal email.">email aliases</em>
   , you can be anonymous online and protect your inbox
   against spams and phishing.
-  Open-source. Made and hosted in Europe.
+  <a href="https://github.com/simple-login">Open-source</a>. Made and hosted in Europe.
 
 hero_cta: Get your aliases for free >>
 
@@ -93,7 +93,7 @@ cta_2_button: Protect your inbox today >>
 partner_title: Our partners
 
 # footer
-footer_1: SimpleLogin is an open-source <b>email alias</b> solution to protect your email address.
+footer_1: SimpleLogin is an <a href="https://github.com/simple-login">open-source</a> <b>email alias</b> solution to protect your email address.
 
 footer_3: SimpleLogin is the product of SimpleLogin SAS, registered in France under the SIREN number 884302134. SimpleLogin SAS is part of <a href="https://proton.me">Proton AG</a>.
 
@@ -106,7 +106,7 @@ footer_join_us: Join Us
 # pricing
 pricing_title: Pricing
 pricing_subtitle: >
-  SimpleLogin is open-source, can be self-hosted and is 100% funded by the community.
+  SimpleLogin is <a href="https://github.com/simple-login">open-source</a>, can be self-hosted and is 100% funded by the community.
   We do not use your data, track you or show you ads. SimpleLogin depends on your support
   to keep the service running and develop new features.
 

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -82,7 +82,7 @@ cta_2_button: Protéger votre boîte mail aujourd'hui >>
 partner_title: Nos partenaires
 
 # footer
-footer_1: SimpleLogin est une solution <a href="https://github.com/simple-login">open source</a> pour protéger votre vie privée.
+footer_1: SimpleLogin est une solution <b><a href="https://github.com/simple-login">open source</a></b> pour protéger votre vie privée.
 
 footer_3: SimpleLogin est le produit de SimpleLogin SAS, enregistré en France dont le SIREN est 884302134. SimpleLogin SAS fait partie de <a href="https://proton.me">Proton AG</a>.
 

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -10,7 +10,7 @@ hero_desc: >
   title="Un alias e-mail (ou juste alias) est une adresse mail
   qui redirige vers une autre adresse">alias e-mail</em>,
   vous pouvez finalement avoir une identité différente pour chaque site-web. Défendre contre les spams, phishing et fuites de données.
-  Open source. Fabriqué en 🇫🇷.
+  <a href="https://github.com/simple-login">Open source</a>. Fabriqué en 🇫🇷.
 
 hero_cta: Créer vos alias maintenant >>
 
@@ -82,7 +82,7 @@ cta_2_button: Protéger votre boîte mail aujourd'hui >>
 partner_title: Nos partenaires
 
 # footer
-footer_1: SimpleLogin est une solution <b>open source</b> pour protéger votre vie privée.
+footer_1: SimpleLogin est une solution <a href="https://github.com/simple-login">open source</a> pour protéger votre vie privée.
 
 footer_3: SimpleLogin est le produit de SimpleLogin SAS, enregistré en France dont le SIREN est 884302134. SimpleLogin SAS fait partie de <a href="https://proton.me">Proton AG</a>.
 
@@ -94,7 +94,7 @@ footer_join_us: Nous rejoindre
 
 pricing_title: Offres
 pricing_subtitle: >
-  SimpleLogin est open source, peut être installé sur votre serveur et 100% financé par la communauté.
+  SimpleLogin est <a href="https://github.com/simple-login">open source</a>, peut être installé sur votre serveur et 100% financé par la communauté.
   Nous ne vendons pas vos données et ne vous traquons pas.
   SimpleLogin dépend de votre support pour être durable et développer de nouvelles fonctionalités.
 


### PR DESCRIPTION
It directs to the GitHub organization.
It's on the homepage description

(Receive and send emails anonymously
With email aliases , you can be anonymous online and protect your inbox against spams and phishing. Open-source. Made and hosted in Europe.), 

in the footer and also the pricing description (SimpleLogin is open-source, can be self-hosted...).