### PR TITLE
Update delete account button URL to account_settings

### DIFF
--- a/data/faq/en/tech.yaml
+++ b/data/faq/en/tech.yaml
@@ -17,7 +17,7 @@
 
 - question: How can I delete my account?
   answer: >
-    At the bottom of the <a href="https://app.simplelogin.io/dashboard/setting">Settings page</a>,
+    At the bottom of the <a href="https://app.simplelogin.io/dashboard/account_setting">Settings page</a>,
         you can delete your account. This operation is irreversible and we have no way to recover your data.
 
 - question: Can I use email aliases for important services like bank, government, etc?


### PR DESCRIPTION
This PR updates the Delete Account button URL from settings to account_settings, to reflect correct page URL. 
FIX: #129